### PR TITLE
Add timeout option & optimize the process of install and uninstall

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,20 +5,21 @@ This command will help you to install OpenFunction and its dependencies.
 ## Parameters
 
 ```shell
---all              For installing all dependencies.
---async            For installing OpenFunction Async Runtime (Dapr & Keda).
---cert-manager     For installing Cert Manager.
---dapr             For installing Dapr.
---dry-run          Used to prompt for the components and their versions to be installed by the current command.
---ingress          For installing Ingress Nginx.
---keda             For installing Keda.
---knative          For installing Knative Serving (with Kourier as default gateway).
---region-cn        For users in China to speed up the download process of dependent components.
---shipwright       For installing ShipWright.
---sync             For installing OpenFunction Sync Runtime (To be supported).
---upgrade          Upgrade components to target version while installing.
---verbose          Show verbose information.
---version string   Used to specify the version of OpenFunction to be installed. The permitted versions are: v0.3.1, v0.4.0, latest. (default "v0.4.0")
+--all                For installing all dependencies.
+--async              For installing OpenFunction Async Runtime (Dapr & Keda).
+--cert-manager       For installing Cert Manager.
+--dapr               For installing Dapr.
+--dry-run            Used to prompt for the components and their versions to be installed by the current command.
+--ingress            For installing Ingress Nginx.
+--keda               For installing Keda.
+--knative            For installing Knative Serving (with Kourier as default gateway).
+--region-cn          For users in China to speed up the download process of dependent components.
+--shipwright         For installing ShipWright.
+--sync               For installing OpenFunction Sync Runtime (To be supported).
+--upgrade            Upgrade components to target version while installing.
+--verbose            Show verbose information.
+--version string     Used to specify the version of OpenFunction to be installed. The permitted versions are: v0.3.1, v0.4.0, latest. (default "v0.4.0")
+--timeout duration   Set timeout time. Default is 5 minutes. (default 5m0s)
 ```
 
 ## Use Cases

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -5,20 +5,21 @@ This command will help you to uninstall OpenFunction and its dependencies.
 ## Parameters
 
 ```shell
---all              For uninstalling all dependencies.
---async            For uninstalling OpenFunction Async Runtime (Dapr & Keda).
---cert-manager     For uninstalling Cert Manager.
---dapr             For uninstalling Dapr.
---dry-run          Used to prompt for the components and their versions to be uninstalled by the current command.
---ingress          For uninstalling Ingress Nginx.
---keda             For uninstalling KEDA.
---knative          For uninstalling Knative Serving (with Kourier as default gateway).
---region-cn        For users in China to uninstall dependent components.
---shipwright       For uninstalling ShipWright.
---sync             For uninstalling OpenFunction Sync Runtime (To be supported).
---verbose          Show verbose information.
---version string   Used to specify the version of OpenFunction to be uninstalled. (default "v0.4.0")
---wait             Awaiting the results of the uninstallation.
+--all                For uninstalling all dependencies.
+--async              For uninstalling OpenFunction Async Runtime (Dapr & Keda).
+--cert-manager       For uninstalling Cert Manager.
+--dapr               For uninstalling Dapr.
+--dry-run            Used to prompt for the components and their versions to be uninstalled by the current command.
+--ingress            For uninstalling Ingress Nginx.
+--keda               For uninstalling KEDA.
+--knative            For uninstalling Knative Serving (with Kourier as default gateway).
+--region-cn          For users in China to uninstall dependent components.
+--shipwright         For uninstalling ShipWright.
+--sync               For uninstalling OpenFunction Sync Runtime (To be supported).
+--verbose            Show verbose information.
+--version string     Used to specify the version of OpenFunction to be uninstalled. (default "v0.4.0")
+--wait               Awaiting the results of the uninstallation.
+--timeout duration   Set timeout time. Default is 5 minutes. (default 5m0s)
 ```
 
 ## Use Cases

--- a/pkg/cmd/subcommand/install.go
+++ b/pkg/cmd/subcommand/install.go
@@ -60,6 +60,7 @@ type Install struct {
 	OpenFunctionVersion string
 	DryRun              bool
 	WithUpgrade         bool
+	Timeout             time.Duration
 }
 
 func init() {
@@ -124,6 +125,7 @@ The permitted parameters are: --async, --knative, --shipwright, --cert-manager, 
 	cmd.Flags().BoolVar(&i.DryRun, "dry-run", false, "Used to prompt for the components and their versions to be installed by the current command.")
 	cmd.Flags().BoolVar(&i.WithUpgrade, "upgrade", false, "Upgrade components to target version while installing.")
 	cmd.Flags().StringVar(&i.OpenFunctionVersion, "version", "v0.4.0", "Used to specify the version of OpenFunction to be installed. The permitted versions are: v0.3.1, v0.4.0, latest.")
+	cmd.Flags().DurationVar(&i.Timeout, "timeout", 5*time.Minute, "Set timeout time. Default is 5 minutes.")
 	// In order to avoid too many options causing misunderstandings among users,
 	// we have hidden the following parameters,
 	// but you can still find their usage instructions in the documentation.
@@ -150,12 +152,14 @@ func (i *Install) ValidateArgs(cmd *cobra.Command, args []string) error {
 }
 
 func (i *Install) RunInstall(cl *k8s.Clientset, cmd *cobra.Command) error {
-	operator := common.NewOperator(runtime.GOOS, i.OpenFunctionVersion, i.RegionCN, i.Verbose)
+	operator := common.NewOperator(runtime.GOOS, i.OpenFunctionVersion, i.Timeout, i.RegionCN, i.Verbose)
 	ti := util.NewTaskInformer("")
 	continueFunc := func() bool {
 		reader := bufio.NewReader(os.Stdin)
-		fmt.Fprintln(w, ti.BeforeTask("You can see the list of components to be installed and the list of components already exist in the cluster.\n"+
-			"You have used the `--upgrade` parameter, which means that the installation process will overwrite the components that already exist in the cluster.\n"+
+		fmt.Fprintln(w, ti.BeforeTask("You can see the list of components to be installed "+
+			"and the list of components already exist in the cluster.\n"+
+			"You have used the `--upgrade` parameter, which means that the installation process "+
+			"will overwrite the components that already exist in the cluster.\n"+
 			"Make sure you know what happens when you do this.\n"+
 			"Enter 'y' to continue and 'n' to abort:"))
 
@@ -174,18 +178,19 @@ func (i *Install) RunInstall(cl *k8s.Clientset, cmd *cobra.Command) error {
 		}
 	}
 
-	ctx, done := context.WithCancel(
+	ctx, done := context.WithTimeout(
 		context.Background(),
+		i.Timeout,
 	)
 	defer done()
 
 	inventoryPending := i.checkConditionsAndGetInventory()
-	inventoryExist := getExistComponentsInventory(ctx, cl)
+	inventoryExist := getExistComponentsInventory(ctx, cl, false)
 
 	fmt.Fprintln(w, ti.BeforeTask("Start installing OpenFunction and its dependencies.\n"+
 		"Here are the components and corresponding versions to be installed for this installation:"))
 	printInventory(inventoryPending)
-	fmt.Fprintln(w, ti.BeforeTask("The following components already exist in the current cluster:"))
+	fmt.Fprintln(w, ti.BeforeTask("The following components already exist:"))
 	printInventory(inventoryExist)
 
 	if i.DryRun {
@@ -199,7 +204,6 @@ func (i *Install) RunInstall(cl *k8s.Clientset, cmd *cobra.Command) error {
 	}
 
 	grp1, g1ctx := errgroup.WithContext(ctx)
-	defer g1ctx.Done()
 
 	start := time.Now()
 
@@ -276,7 +280,6 @@ func (i *Install) RunInstall(cl *k8s.Clientset, cmd *cobra.Command) error {
 	}
 
 	grp2, g2ctx := errgroup.WithContext(ctx)
-	defer g2ctx.Done()
 
 	grp2.Go(func() error {
 		return i.installOpenFunction(g2ctx, cl, operator)
@@ -353,17 +356,57 @@ func (i *Install) checkConditionsAndGetInventory() map[string]string {
 	return inventory
 }
 
-func getExistComponentsInventory(ctx context.Context, cl *k8s.Clientset) map[string]string {
+func getExistComponentsInventory(ctx context.Context, cl *k8s.Clientset, ignoreMissingComponent bool) map[string]string {
 	// The components of Shipwright and OpenFunction don't have the "app.kubernetes.io/version" label yet.
-	inventory := map[string]string{
-		"Dapr":             common.GetExistComponentVersion(ctx, cl, common.DaprNamespace, "dapr-operator"),
-		"Keda":             common.GetExistComponentVersion(ctx, cl, common.KedaNamespace, "keda-operator"),
-		"Knative Serving":  common.GetExistComponentVersion(ctx, cl, common.KnativeServingNamespace, "controller"),
-		"Ingress Nginx":    common.GetExistComponentVersion(ctx, cl, common.IngressNginxNamespace, "ingress-nginx-controller"),
-		"Cert Manager":     common.GetExistComponentVersion(ctx, cl, common.CertManagerNamespace, "cert-manager"),
-		"Tekton Pipelines": common.GetExistComponentVersion(ctx, cl, common.TektonPipelineNamespace, "tekton-pipelines-controller"),
+	inventory := map[string]string{}
+	if version := common.GetExistComponentVersion(
+		ctx,
+		cl,
+		common.DaprNamespace,
+		"dapr-operator",
+	); version != "" || !ignoreMissingComponent {
+		inventory["Dapr"] = version
 	}
-
+	if version := common.GetExistComponentVersion(
+		ctx,
+		cl,
+		common.KedaNamespace,
+		"keda-operator",
+	); version != "" || !ignoreMissingComponent {
+		inventory["Keda"] = version
+	}
+	if version := common.GetExistComponentVersion(
+		ctx,
+		cl,
+		common.KnativeServingNamespace,
+		"controller",
+	); version != "" || !ignoreMissingComponent {
+		inventory["Knative Serving"] = version
+	}
+	if version := common.GetExistComponentVersion(
+		ctx,
+		cl,
+		common.IngressNginxNamespace,
+		"ingress-nginx-controller",
+	); version != "" || !ignoreMissingComponent {
+		inventory["Ingress Nginx"] = version
+	}
+	if version := common.GetExistComponentVersion(
+		ctx,
+		cl,
+		common.CertManagerNamespace,
+		"cert-manager",
+	); version != "" || !ignoreMissingComponent {
+		inventory["Cert Manager"] = version
+	}
+	if version := common.GetExistComponentVersion(
+		ctx,
+		cl,
+		common.TektonPipelineNamespace,
+		"tekton-pipelines-controller",
+	); version != "" || !ignoreMissingComponent {
+		inventory["Tekton Pipelines"] = version
+	}
 	return inventory
 }
 
@@ -373,7 +416,7 @@ func printInventory(inventory map[string]string) {
 }
 
 func (i *Install) installDapr(ctx context.Context, operator *common.Operator) error {
-	ctx, done := context.WithTimeout(ctx, 5*time.Minute)
+	ctx, done := context.WithCancel(ctx)
 	defer done()
 
 	ti := util.NewTaskInformer("DAPR")
@@ -394,7 +437,7 @@ func (i *Install) installDapr(ctx context.Context, operator *common.Operator) er
 }
 
 func (i *Install) installKeda(ctx context.Context, cl *k8s.Clientset, operator *common.Operator) error {
-	ctx, done := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, done := context.WithCancel(ctx)
 	defer done()
 
 	ti := util.NewTaskInformer("KEDA")
@@ -413,7 +456,7 @@ func (i *Install) installKeda(ctx context.Context, cl *k8s.Clientset, operator *
 }
 
 func (i *Install) installKnativeServing(ctx context.Context, cl *k8s.Clientset, operator *common.Operator) error {
-	ctx, done := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, done := context.WithCancel(ctx)
 	defer done()
 
 	ti := util.NewTaskInformer("KNATIVE")
@@ -439,7 +482,7 @@ func (i *Install) installKnativeServing(ctx context.Context, cl *k8s.Clientset, 
 }
 
 func (i *Install) installShipwright(ctx context.Context, cl *k8s.Clientset, operator *common.Operator) error {
-	ctx, done := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, done := context.WithCancel(ctx)
 	defer done()
 
 	ti := util.NewTaskInformer("SHIPWRIGHT")
@@ -457,7 +500,7 @@ func (i *Install) installShipwright(ctx context.Context, cl *k8s.Clientset, oper
 }
 
 func (i *Install) installCertManager(ctx context.Context, cl *k8s.Clientset, operator *common.Operator) error {
-	ctx, done := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, done := context.WithCancel(ctx)
 	defer done()
 
 	ti := util.NewTaskInformer("CERTMANAGER")
@@ -475,7 +518,7 @@ func (i *Install) installCertManager(ctx context.Context, cl *k8s.Clientset, ope
 }
 
 func (i *Install) installIngress(ctx context.Context, cl *k8s.Clientset, operator *common.Operator) error {
-	ctx, done := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, done := context.WithCancel(ctx)
 	defer done()
 
 	ti := util.NewTaskInformer("INGRESS")
@@ -493,16 +536,14 @@ func (i *Install) installIngress(ctx context.Context, cl *k8s.Clientset, operato
 }
 
 func (i *Install) installOpenFunction(ctx context.Context, cl *k8s.Clientset, operator *common.Operator) error {
-	ctx, done := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, done := context.WithCancel(ctx)
 	defer done()
 
 	ti := util.NewTaskInformer("OPENFUNCTION")
 
 	fmt.Fprintln(w, ti.TaskInfo("Installing OpenFunction..."))
 	if err := operator.InstallOpenFunction(ctx); err != nil {
-		if !strings.Contains(err.Error(), "already exists") {
-			return errors.Wrap(err, ti.TaskFailWithTitle("Failed to install OpenFunction"))
-		}
+		return errors.Wrap(err, ti.TaskFailWithTitle("Failed to install OpenFunction"))
 	}
 	fmt.Fprintln(w, ti.TaskInfo("Checking if OpenFunction is ready..."))
 	if err := operator.CheckOpenFunctionIsReady(ctx, cl); err != nil {


### PR DESCRIPTION
1. add `timeout` option to control the timeout of the entire process
2. fix some `defer` bugs
3. split the Knative Serving uninstallation process
4. split the Shipwright uninstallation process
5. update docs

Signed-off-by: laminar <fangtian@kubesphere.io>