### PR TITLE
fix: yaml path in region-cn mode & update docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -13,18 +13,18 @@ This command will help you to install OpenFunction and its dependencies.
 --ingress            For installing Ingress Nginx.
 --keda               For installing Keda.
 --knative            For installing Knative Serving (with Kourier as default gateway).
---region-cn          For users in China to speed up the download process of dependent components.
+--region-cn          For users who have limited access to gcr.io or github.com.
 --shipwright         For installing ShipWright.
 --sync               For installing OpenFunction Sync Runtime (To be supported).
 --upgrade            Upgrade components to target version while installing.
 --verbose            Show verbose information.
---version string     Used to specify the version of OpenFunction to be installed. The permitted versions are: v0.3.1, v0.4.0, latest. (default "v0.4.0")
+--version string     Used to specify the version of OpenFunction to be installed. (default "v0.4.0")
 --timeout duration   Set timeout time. Default is 5 minutes. (default 5m0s)
 ```
 
 ## Use Cases
 
-### Install OpenFunction with a specified runtime
+### Install OpenFunction with specified runtime
 
 ```shell
 ofn install --async
@@ -50,10 +50,15 @@ ofn install --region-cn --all
 ofn install --upgrade --all
 ```
 
-### Install a specified version of OpenFunction
+### Install particular OpenFunction (default version is v0.4.0)
+
+The available versions are:
+- v0.3.1
+- v0.4.0
+- latest
 
 ```shell
-ofn install --version latest
+ofn install --version v0.4.0
 ```
 
 ## The default compatibility matrix

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -13,7 +13,7 @@ This command will help you to uninstall OpenFunction and its dependencies.
 --ingress            For uninstalling Ingress Nginx.
 --keda               For uninstalling KEDA.
 --knative            For uninstalling Knative Serving (with Kourier as default gateway).
---region-cn          For users in China to uninstall dependent components.
+--region-cn          For users who have limited access to gcr.io or github.com.
 --shipwright         For uninstalling ShipWright.
 --sync               For uninstalling OpenFunction Sync Runtime (To be supported).
 --verbose            Show verbose information.
@@ -24,7 +24,7 @@ This command will help you to uninstall OpenFunction and its dependencies.
 
 ## Use Cases
 
-#### Uninstalling OpenFunction with a specify runtime
+### Uninstall a specified runtime of OpenFunction
 
 ```shell
 ofn uninstall --async
@@ -36,7 +36,7 @@ or
 ofn uninstall --knative
 ```
 
-#### Support users in China to uninstall
+### For users who have limited access to gcr.io or github.com to uninstall OpenFunction
 
 > This only makes sense when you have installed OpenFunction (and its dependencies) with the `--region-cn` parameter.
 
@@ -44,18 +44,23 @@ ofn uninstall --knative
 ofn uninstall --region-cn --all
 ```
 
-#### You can wait for the end of the installation process
+### You can wait for the uninstallation process
 
 > It will take time to wait for namespaces cleanup
 
 ```shell
-ofn uninstall  --all --wait
+ofn uninstall --all --wait
 ```
 
-#### Supports uninstallation of multiple versions of OpenFunction
+### Uninstall a specific version of OpenFunction (default is v0.4.0)
+
+The available versions are:
+- v0.3.1
+- v0.4.0
+- latest
 
 ```shell
-ofn uninstall --version latest
+ofn uninstall --version v0.4.0
 ```
 
 ## Inventory

--- a/pkg/cmd/util/helpers.go
+++ b/pkg/cmd/util/helpers.go
@@ -43,12 +43,3 @@ func IgnoreNotFoundErr(err error) error {
 	}
 	return err
 }
-
-func IsInSlice(s string, target []string) bool {
-	for _, t := range target {
-		if t == s {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/components/inventory/cert-manager.go
+++ b/pkg/components/inventory/cert-manager.go
@@ -13,7 +13,7 @@ const (
 	CertManagerVersionEnv                    = "CERT_MANAGER_VERSION"
 	CertManagerYamlEnv                       = "CERT_MANAGER_YAML"
 	CertManagerDefaultYamlFileTmpl           = "https://github.com/jetstack/cert-manager/releases/download/%s%s/cert-manager.yaml"
-	CertManagerDefaultYamlFileTmplInRegionCN = "https://github.com/kedacore/keda/releases/download/%s%s/keda-%s.yaml"
+	CertManagerDefaultYamlFileTmplInRegionCN = "https://openfunction.sh1a.qingstor.com/cert-manager/%s%s/cert-manager.yaml"
 )
 
 type certManager struct {
@@ -56,7 +56,7 @@ func (i *certManager) GetYamlFile(ver string) (map[string]string, error) {
 	} else {
 		cmVersion := fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch())
 		if i.regionCN {
-			yamls["MAIN"] = fmt.Sprintf(CertManagerDefaultYamlFileTmplInRegionCN, "v", cmVersion, cmVersion)
+			yamls["MAIN"] = fmt.Sprintf(CertManagerDefaultYamlFileTmplInRegionCN, "v", cmVersion)
 			return yamls, nil
 		}
 		yamls["MAIN"] = fmt.Sprintf(CertManagerDefaultYamlFileTmpl, "v", cmVersion)

--- a/pkg/components/inventory/ingress.go
+++ b/pkg/components/inventory/ingress.go
@@ -13,7 +13,7 @@ const (
 	IngressVersionEnv                    = "INGRESS_NGINX_VERSION"
 	IngressYamlEnv                       = "INGRESS_NGINX_YAML"
 	IngressDefaultYamlFileTmpl           = "https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-%s%s/deploy/static/provider/cloud/deploy.yaml"
-	IngressDefaultYamlFileTmplInRegionCN = "https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-%s%s/deploy/static/provider/cloud/deploy.yaml"
+	IngressDefaultYamlFileTmplInRegionCN = "https://openfunction.sh1a.qingstor.com/ingress-nginx/%s%s/deploy.yml"
 )
 
 type ingress struct {

--- a/pkg/components/inventory/inventory.go
+++ b/pkg/components/inventory/inventory.go
@@ -14,9 +14,9 @@ const (
 	DefaultKnativeServingVersionOnK8Sv118       = "0.23.3"
 	DefaultKnativeServingVersionOnK8Sv119       = "0.25.2"
 	DefaultKnativeServingVersionOnK8Sv120       = "1.0.1"
-	DefaultKourierVersionOnK8Sv117              = "0.21.1"
-	DefaultKourierVersionOnK8Sv118              = "0.23.3"
-	DefaultKourierVersionOnK8Sv119              = "0.25.2"
+	DefaultKourierVersionOnK8Sv117              = "0.21.0"
+	DefaultKourierVersionOnK8Sv118              = "0.23.0"
+	DefaultKourierVersionOnK8Sv119              = "0.25.0"
 	DefaultKourierVersionOnK8Sv120              = "1.0.1"
 	DefaultServingDefaultDomainVersionOnK8Sv117 = "0.21.1"
 	DefaultServingDefaultDomainVersionOnK8Sv118 = "0.23.3"
@@ -27,8 +27,8 @@ const (
 	DefaultTektonPipelinesVersionOnK8Sv119      = "0.29.0"
 	DefaultTektonPipelinesVersionOnK8Sv120      = "0.30.0"
 	DefaultShipwrightVersion                    = "0.6.1"
-	DefaultCertManagerVersion                   = "1.1.0"
-	DefaultIngressNginxVersion                  = "1.5.4"
+	DefaultCertManagerVersion                   = "1.5.4"
+	DefaultIngressNginxVersion                  = "1.1.0"
 	DefaultOpenFunctionVersion                  = "0.4.0"
 )
 

--- a/pkg/components/inventory/keda.go
+++ b/pkg/components/inventory/keda.go
@@ -13,7 +13,7 @@ const (
 	KedaVersionEnv                    = "KEDA_VERSION"
 	KedaYamlEnv                       = "KEDA_YAML"
 	KedaDefaultYamlFileTmpl           = "https://github.com/kedacore/keda/releases/download/%s%s/keda-%s.yaml"
-	KedaDefaultYamlFileTmplInRegionCN = "https://github.com/kedacore/keda/releases/download/%s%s/keda-%s.yaml"
+	KedaDefaultYamlFileTmplInRegionCN = "https://openfunction.sh1a.qingstor.com/keda/%s%s/keda-%s.yaml"
 )
 
 type keda struct {

--- a/pkg/components/inventory/knative.go
+++ b/pkg/components/inventory/knative.go
@@ -14,8 +14,8 @@ const (
 	KnativeServingVersionEnv                    = "KNATIVE_SERVING_VERSION"
 	KnativeServingCrdYamlEnv                    = "KNATIVE_SERVING_CRD_YAML"
 	KnativeServingCoreYamlEnv                   = "KNATIVE_SERVING_CORE_YAML"
-	KnativeServingDefaultYamlFileTmpl           = "https://github.com/knative/serving/releases/download/%s%d.%d.%d/serving-%s.yaml"
-	KnativeServingDefaultYamlFileTmplInRegionCN = "https://github.com/knative/serving/releases/download/%s%d.%d.%d/serving-%s.yaml"
+	KnativeServingDefaultYamlFileTmpl           = "https://github.com/knative/serving/releases/download/%s%s/serving-%s.yaml"
+	KnativeServingDefaultYamlFileTmplInRegionCN = "https://openfunction.sh1a.qingstor.com/knative/serving/%s%s/serving-%s.yml"
 )
 
 type knativeServing struct {
@@ -59,24 +59,25 @@ func (i *knativeServing) GetYamlFile(knVersion string) (map[string]string, error
 	if v, err := version.ParseGeneric(knVersion); err != nil {
 		return nil, err
 	} else {
+		knativeVersion := fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch())
 		switch v.Major() {
 		case 0:
 			if i.regionCN {
-				yamls["CRD"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmplInRegionCN, "v", v.Major(), v.Minor(), v.Patch(), "crds")
-				yamls["CORE"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmplInRegionCN, "v", v.Major(), v.Minor(), v.Patch(), "core")
+				yamls["CRD"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmplInRegionCN, "v", knativeVersion, "crds")
+				yamls["CORE"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmplInRegionCN, "v", knativeVersion, "core")
 				return yamls, nil
 			}
-			yamls["CRD"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmpl, "v", v.Major(), v.Minor(), v.Patch(), "crds")
-			yamls["CORE"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmpl, "v", v.Major(), v.Minor(), v.Patch(), "core")
+			yamls["CRD"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmpl, "v", knativeVersion, "crds")
+			yamls["CORE"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmpl, "v", knativeVersion, "core")
 			return yamls, nil
 		case 1:
 			if i.regionCN {
-				yamls["CRD"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmplInRegionCN, "knative-v", v.Major(), v.Minor(), v.Patch(), "crds")
-				yamls["CORE"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmplInRegionCN, "knative-v", v.Major(), v.Minor(), v.Patch(), "core")
+				yamls["CRD"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmplInRegionCN, "knative-v", knativeVersion, "crds")
+				yamls["CORE"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmplInRegionCN, "knative-v", knativeVersion, "core")
 				return yamls, nil
 			}
-			yamls["CRD"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmpl, "knative-v", v.Major(), v.Minor(), v.Patch(), "crds")
-			yamls["CORE"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmpl, "knative-v", v.Major(), v.Minor(), v.Patch(), "core")
+			yamls["CRD"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmpl, "knative-v", knativeVersion, "crds")
+			yamls["CORE"] = fmt.Sprintf(KnativeServingDefaultYamlFileTmpl, "knative-v", knativeVersion, "core")
 			return yamls, nil
 		default:
 			return nil, errors.New("wrong format")

--- a/pkg/components/inventory/kourier.go
+++ b/pkg/components/inventory/kourier.go
@@ -13,8 +13,8 @@ const (
 	KourierRecordName                    = "kourier"
 	KourierVersionEnv                    = "KOURIER_VERSION"
 	KourierYamlEnv                       = "KOURIER_YAML"
-	KourierDefaultYamlFileTmpl           = "https://github.com/knative-sandbox/net-kourier/releases/download/%s%d.%d.%d/kourier.yaml"
-	KourierDefaultYamlFileTmplInRegionCN = "https://github.com/knative-sandbox/net-kourier/releases/download/%s%d.%d.%d/release.yaml"
+	KourierDefaultYamlFileTmpl           = "https://github.com/knative-sandbox/net-kourier/releases/download/%s%s/kourier.yaml"
+	KourierDefaultYamlFileTmplInRegionCN = "https://openfunction.sh1a.qingstor.com/knative/net-kourier/%s%s/kourier.yml"
 )
 
 type kourier struct {
@@ -55,20 +55,21 @@ func (i *kourier) GetYamlFile(ver string) (map[string]string, error) {
 	if v, err := version.ParseGeneric(ver); err != nil {
 		return nil, err
 	} else {
+		kourierVersion := fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch())
 		switch v.Major() {
 		case 0:
 			if i.regionCN {
-				yamls["MAIN"] = fmt.Sprintf(KourierDefaultYamlFileTmplInRegionCN, "v", v.Major(), v.Minor(), v.Patch())
+				yamls["MAIN"] = fmt.Sprintf(KourierDefaultYamlFileTmplInRegionCN, "v", kourierVersion)
 				return yamls, nil
 			}
-			yamls["MAIN"] = fmt.Sprintf(KourierDefaultYamlFileTmpl, "v", v.Major(), v.Minor(), v.Patch())
+			yamls["MAIN"] = fmt.Sprintf(KourierDefaultYamlFileTmpl, "v", kourierVersion)
 			return yamls, nil
 		case 1:
 			if i.regionCN {
-				yamls["MAIN"] = fmt.Sprintf(KourierDefaultYamlFileTmpl, "knative-v", v.Major(), v.Minor(), v.Patch())
+				yamls["MAIN"] = fmt.Sprintf(KourierDefaultYamlFileTmplInRegionCN, "knative-v", kourierVersion)
 				return yamls, nil
 			}
-			yamls["MAIN"] = fmt.Sprintf(KourierDefaultYamlFileTmpl, "knative-v", v.Major(), v.Minor(), v.Patch())
+			yamls["MAIN"] = fmt.Sprintf(KourierDefaultYamlFileTmpl, "knative-v", kourierVersion)
 			return yamls, nil
 		default:
 			return nil, errors.New("wrong format")

--- a/pkg/components/inventory/openfunction.go
+++ b/pkg/components/inventory/openfunction.go
@@ -12,7 +12,7 @@ const (
 	OpenFunctionRecordName                    = "openFunction"
 	OpenFunctionYamlEnv                       = "OPENFUNCTION_YAML"
 	OpenFunctionDefaultYamlFileTmpl           = "https://github.com/OpenFunction/OpenFunction/releases/download/%s%s/bundle.yaml"
-	OpenFunctionDefaultYamlFileTmplInRegionCN = "https://github.com/OpenFunction/OpenFunction/releases/download/%s%s/bundle.yaml"
+	OpenFunctionDefaultYamlFileTmplInRegionCN = "https://openfunction.sh1a.qingstor.com/openfunction/%s%s/bundle.yml"
 )
 
 type openFunction struct {

--- a/pkg/components/inventory/serving-default-domain.go
+++ b/pkg/components/inventory/serving-default-domain.go
@@ -14,7 +14,7 @@ const (
 	ServingDefaultDomainVersionEnv                    = "DEFAULT_DOMAIN_VERSION"
 	ServingDefaultDomainYamlEnv                       = "DEFAULT_DOMAIN_YAML"
 	ServingDefaultDomainDefaultYamlFileTmpl           = "https://github.com/knative/serving/releases/download/%s%s/serving-default-domain.yaml"
-	ServingDefaultDomainDefaultYamlFileTmplInRegionCN = "https://github.com/knative-sandbox/net-kourier/releases/download/%s%d.%d.%d/release.yaml"
+	ServingDefaultDomainDefaultYamlFileTmplInRegionCN = "https://openfunction.sh1a.qingstor.com/knative/serving/%s%s/serving-default-domain.yml"
 )
 
 type defaultDomain struct {
@@ -59,14 +59,14 @@ func (i *defaultDomain) GetYamlFile(ver string) (map[string]string, error) {
 		switch v.Major() {
 		case 0:
 			if i.regionCN {
-				yamls["MAIN"] = fmt.Sprintf(ServingDefaultDomainDefaultYamlFileTmplInRegionCN, "v", v.Major(), v.Minor(), v.Patch())
+				yamls["MAIN"] = fmt.Sprintf(ServingDefaultDomainDefaultYamlFileTmplInRegionCN, "v", ddVersion)
 				return yamls, nil
 			}
 			yamls["MAIN"] = fmt.Sprintf(ServingDefaultDomainDefaultYamlFileTmpl, "v", ddVersion)
 			return yamls, nil
 		case 1:
 			if i.regionCN {
-				yamls["MAIN"] = fmt.Sprintf(ServingDefaultDomainDefaultYamlFileTmplInRegionCN, "knative-v", v.Major(), v.Minor(), v.Patch())
+				yamls["MAIN"] = fmt.Sprintf(ServingDefaultDomainDefaultYamlFileTmplInRegionCN, "knative-v", ddVersion)
 				return yamls, nil
 			}
 			yamls["MAIN"] = fmt.Sprintf(ServingDefaultDomainDefaultYamlFileTmpl, "knative-v", ddVersion)

--- a/pkg/components/inventory/tekton.go
+++ b/pkg/components/inventory/tekton.go
@@ -13,7 +13,7 @@ const (
 	TektonPipelinesVersionEnv                    = "TEKTON_PIPELINES_VERSION"
 	TektonPipelinesYamlEnv                       = "TEKTON_PIPELINES_YAML"
 	TektonPipelinesDefaultYamlFileTmpl           = "https://storage.googleapis.com/tekton-releases/pipeline/previous/%s%s/release.yaml"
-	TektonPipelinesDefaultYamlFileTmplInRegionCN = "https://storage.googleapis.com/tekton-releases/pipeline/previous/%s%s/release.yaml"
+	TektonPipelinesDefaultYamlFileTmplInRegionCN = "https://openfunction.sh1a.qingstor.com/tekton/pipeline/%s%s/release.yml"
 )
 
 type tektonPipelines struct {

--- a/pkg/components/linux/linux.go
+++ b/pkg/components/linux/linux.go
@@ -139,6 +139,12 @@ func (e *Executor) GetInventoryRecord(ctx context.Context) (*inventory.Record, e
 		return nil, err
 	}
 
+	if err := os.Mkdir(filepath.Join(dirname, components.OpenFunctionDir), os.ModePerm); err != nil {
+		if !strings.Contains(err.Error(), "file exists") {
+			return nil, err
+		}
+	}
+
 	filePath := filepath.Join(dirname, components.OpenFunctionDir, components.RecordFileName)
 
 	if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
1. fix YAML file path in `region-cn` mode
2. update docs and command helps
3. adjust some logic (check if the OpenFunction version is valid, wait for Knative serving-crds to be ready before installing Knative serving-core)
4. update the channel of `os.Signal` to channel with a buffer

Signed-off-by: laminar <fangtian@kubesphere.io>