### PR TITLE
fix: let all spinners terminate correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.22.0
 	k8s.io/apimachinery v0.22.0

--- a/pkg/cmd/subcommand/install.go
+++ b/pkg/cmd/subcommand/install.go
@@ -225,9 +225,9 @@ func (i *Install) RunInstall(cl *k8s.Clientset, cmd *cobra.Command) error {
 		} else {
 			util.BeforeTask("The following existing components will be upgraded:")
 		}
-		for i, exist := range inventoryExist {
+		for idx, exist := range inventoryExist {
 			if exist {
-				util.BeforeTask(fmt.Sprintf("\t- %s", i))
+				util.BeforeTask(fmt.Sprintf("\t- %s", idx))
 			}
 		}
 	}

--- a/pkg/cmd/subcommand/uninstall.go
+++ b/pkg/cmd/subcommand/uninstall.go
@@ -198,15 +198,13 @@ func (i *Uninstall) RunUninstall(cl *k8s.Clientset, cmd *cobra.Command) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get pending inventory")
 	}
-	inventoryExist, err := operator.GetInventoryRecord(ctx, true)
-	if err != nil {
-		return errors.Wrap(err, "failed to get inventory record")
-	}
 	operator.Inventory = inventoryPending
 
 	util.BeforeTask("Start uninstalling OpenFunction and its dependencies.")
-	util.BeforeTask("The following components already exist:")
-	printInventory(inventoryExist)
+	util.BeforeTask("The following component(s) will be uninstalled:")
+	for component, _ := range inventoryPending {
+		util.BeforeTask(fmt.Sprintf("\t- %s", component))
+	}
 
 	if i.DryRun {
 		return nil

--- a/pkg/cmd/util/spinners/spinner.go
+++ b/pkg/cmd/util/spinners/spinner.go
@@ -29,6 +29,7 @@ type Spinner struct {
 	status  *synx.Int
 	group   *SpinnerGroup
 	name    *string
+	IsDead  bool
 }
 
 func (s *Spinner) WithName(name string) *Spinner {
@@ -67,7 +68,6 @@ func (s *Spinner) ErrorWithMessage(message string, err error) {
 	s.Update(message)
 	s.stop(errorStatus)
 	if err != nil {
-		s.group.err = err
 		s.group.errC <- err
 	}
 }
@@ -75,7 +75,7 @@ func (s *Spinner) ErrorWithMessage(message string, err error) {
 func (s *Spinner) stop(status int) {
 	s.status.SetValue(status)
 	s.group.redraw()
-	s.group.Done()
+	// s.group.Done()
 }
 
 func (s *Spinner) refresh() string {


### PR DESCRIPTION
For issue [#233](https://github.com/OpenFunction/OpenFunction/issues/223)

Use spinnerGroup to unify the lifecycle of all spinners to replace the self-destruction of spinners.

Signed-off-by: laminar <fangtian@kubesphere.io>