### PR TITLE
fix nil pointer panic

### DIFF
--- a/pkg/components/common/common.go
+++ b/pkg/components/common/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	ospkg "os"
 	"strings"
 	"time"
 
@@ -68,6 +69,9 @@ func NewOperator(os string, version string, timeout time.Duration, inRegionCN bo
 	switch os {
 	case "linux":
 		op.executor = linux.NewExecutor(verbose)
+	default:
+		fmt.Fprint(ospkg.Stderr, "unsupported os: ", os)
+		ospkg.Exit(1)
 	}
 	return op
 }


### PR DESCRIPTION
### What does this PR do?
Fix a nil pointer panic caused by missing a `default` case.

![image](https://user-images.githubusercontent.com/43993589/153383474-80d66aea-6ec5-4b8c-8520-30f177e61717.png)
