### PR TITLE
Adjust the flags for "ofn install" and "ofn uninstall".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,11 +89,18 @@ BINS_OUT_DIR := $(OUT_DIR)
 # Target: build                                                                #
 ################################################################################
 .PHONY: build
-build: fmt vet $(CLI_BINARY)
+build: test $(CLI_BINARY)
 
 $(CLI_BINARY):
 	CGO_ENABLED=$(CGO) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GCFLAGS) -ldflags '$(LDFLAGS)' \
 	-o $(BINS_OUT_DIR)/$(CLI_BINARY)_$(GOOS)_$(GOARCH)$(BINARY_EXT) cmd/main.go;
+
+################################################################################
+# Target: build                                                                #
+################################################################################
+.PHONY: test
+test: fmt vet
+	go test -v ./... -coverprofile cover.out
 
 ################################################################################
 # Target: lint                                                                 #

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,36 +5,32 @@ This command will help you to install OpenFunction and its dependencies.
 ## Parameters
 
 ```shell
---all                For installing all dependencies.
---async              For installing OpenFunction Async Runtime (Dapr & Keda).
---cert-manager       For installing Cert Manager.
---dapr               For installing Dapr.
---dry-run            Used to prompt for the components and their versions to be installed by the current command.
---ingress            For installing Ingress Nginx.
---keda               For installing Keda.
---knative            For installing Knative Serving (with Kourier as default gateway).
---region-cn          For users who have limited access to gcr.io or github.com.
---shipwright         For installing ShipWright.
---sync               For installing OpenFunction Sync Runtime (To be supported).
---upgrade            Upgrade components to target version while installing.
---yes                Automatic yes to prompts. ('-y' as a short form)
---verbose            Show verbose information.
---version string     Used to specify the version of OpenFunction to be installed. (default "v0.4.0")
---timeout duration   Set timeout time. Default is 5 minutes. (default 5m0s)
+      --all                For installing all dependencies.
+      --dry-run            Used to prompt for the components and their versions to be installed by the current command.
+  -h, --help               help for install
+      --ingress string     The type of ingress controller to be installed, optionally "nginx". (default "nginx")
+      --region-cn          For users who have limited access to gcr.io or github.com.
+  -r, --runtime strings    List of runtimes to be installed, optionally "knative", "async". (default [knative])
+      --timeout duration   Set timeout time. Default is 10 minutes. (default 10m0s)
+      --upgrade            Upgrade components to target version while installing.
+      --verbose            Show verbose information.
+      --version string     Used to specify the version of OpenFunction to be installed.
+      --without-ci         Skip the installation of CI components.
+  -y, --yes                Automatic yes to prompts.
 ```
 
 ## Use Cases
 
-### Install OpenFunction with a specific runtime
+### Install OpenFunction with specific runtime(s)
 
 ```shell
-ofn install --async
+ofn install --runtime async
 ```
 
 or
 
 ```shell
-ofn install --knative
+ofn install --runtime knative,async
 ```
 
 ### Install OpenFunction with limited access to gcr.io or github.com
@@ -71,17 +67,16 @@ The OpenFunction CLI provides a default compatibility matrix based on which Open
 
 The OpenFunction CLI keeps the installed component details in `$home/.ofn/<cluster name>-inventory.yaml`.
 
-| Components             | Kubernetes 1.17 | Kubernetes 1.18 | Kubernetes 1.19 | Kubernetes 1.20+ | CLI Option       | Description                                    |
-| ---------------------- | --------------- | --------------- | --------------- | ---------------- | ---------------- | ---------------------------------------------- |
-| Knative Serving        | 0.21.1          | 0.23.3          | 0.25.2          | 1.0.1            | `--knative`      | The synchronous function runtime               |
-| Kourier                | 0.21.0          | 0.23.0          | 0.25.0          | 1.0.1            | `--knative`      | The default network layer for Knative          |
-| Serving Default Domain | 0.21.0          | 0.23.0          | 0.25.0          | 1.0.1            | `--knative`      | The default DNS layout for Knative             |
-| Dapr                   | 1.5.1           | 1.5.1           | 1.5.1           | 1.5.1            | `--async`        | The distributed application runtime of asynchronous function |
-| Keda                   | 2.4.0           | 2.4.0           | 2.4.0           | 2.4.0            | `--async`        | The autoscaler of asynchronous function runtime|
-| Shipwright             | 0.6.1           | 0.6.1           | 0.6.1           | 0.6.1            | `--shipwright`   | The function build framework                   |
-| Tekton Pipelines       | 0.23.0          | 0.26.0          | 0.29.0          | 0.30.0           | `--shipwright`   | The function build pipeline                    |
-| Cert Manager           | 1.5.4           | 1.5.4           | 1.5.4           | 1.5.4            | `--cert-manager` | OpenFunction webhook Certificate manager (For OpenFunction v0.4.0+ only). |
-| Ingress Nginx          | na              | na              | 1.1.0           | 1.1.0            | `--ingress`      | Function ingress controller (For OpenFunction v0.4.0+ only). |
+| Components             | Kubernetes 1.17 | Kubernetes 1.18 | Kubernetes 1.19 | Kubernetes 1.20+ | CLI Option                                | Description                                                  |
+| ---------------------- | --------------- | --------------- | --------------- | ---------------- | ----------------------------------------- | ------------------------------------------------------------ |
+| Knative Serving        | 0.21.1          | 0.23.3          | 0.25.2          | 1.0.1            | `--runtime knative`, `--with-knative`     | The synchronous function runtime                             |
+| Kourier                | 0.21.0          | 0.23.0          | 0.25.0          | 1.0.1            | `--runtime knative`, `--with-knative`     | The default network layer for Knative                        |
+| Serving Default Domain | 0.21.0          | 0.23.0          | 0.25.0          | 1.0.1            | `--runtime knative`, `--with-knative`     | The default DNS layout for Knative                           |
+| Dapr                   | 1.5.1           | 1.5.1           | 1.5.1           | 1.5.1            | `--runtime async`, `--with-dapr`          | The distributed application runtime of asynchronous function |
+| Keda                   | 2.4.0           | 2.4.0           | 2.4.0           | 2.4.0            | `--runtime async`, `--with-keda`          | The autoscaler of asynchronous function runtime              |
+| Shipwright             | 0.6.1           | 0.6.1           | 0.6.1           | 0.6.1            | `--without-ci`                            | The function build framework                                 |
+| Tekton Pipelines       | 0.23.0          | 0.26.0          | 0.29.0          | 0.30.0           | `--without-ci`                            | The function build pipeline                                  |
+| Ingress Nginx          | na              | na              | 1.1.0           | 1.1.0            | `--ingress nginx`, `--with-ingress-nginx` | Function ingress controller (For OpenFunction v0.4.0+ only). |
 
 > The function ingress capability (i.e. OpenFunction Domain) can only be used in Kubernetes v1.19+.
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -5,36 +5,31 @@ This command will help you to uninstall OpenFunction and its dependencies.
 ## Parameters
 
 ```shell
---all                For uninstalling all dependencies.
---async              For uninstalling OpenFunction Async Runtime (Dapr & Keda).
---cert-manager       For uninstalling Cert Manager.
---dapr               For uninstalling Dapr.
---dry-run            Used to prompt for the components and their versions to be uninstalled by the current command.
---ingress            For uninstalling Ingress Nginx.
---keda               For uninstalling KEDA.
---knative            For uninstalling Knative Serving (with Kourier as default gateway).
---region-cn          For users who have limited access to gcr.io or github.com.
---shipwright         For uninstalling ShipWright.
---sync               For uninstalling OpenFunction Sync Runtime (To be supported).
---verbose            Show verbose information.
---yes                Automatic yes to prompts. ('-y' as a short form)
---version string     Used to specify the version of OpenFunction to be uninstalled.
---wait               Awaiting the results of the uninstallation.
---timeout duration   Set timeout time. Default is 5 minutes. (default 5m0s)
+      --all                For uninstalling all dependencies.
+      --dry-run            Used to prompt for the components and their versions to be uninstalled by the current command.
+  -h, --help               help for uninstall
+      --region-cn          For users who have limited access to gcr.io or github.com.
+  -r, --runtime strings    List of runtimes to be uninstalled, optionally "knative", "async". (default [knative])
+      --timeout duration   Set timeout time. Default is 10 minutes. (default 10m0s)
+      --verbose            Show verbose information.
+      --version string     Used to specify the version of OpenFunction to be uninstalled.
+      --wait               Awaiting the results of the uninstallation.
+      --with-ci            For uninstalling the CI components.
+  -y, --yes                Automatic yes to prompts.
 ```
 
 ## Use Cases
 
-### Uninstall a specified runtime of OpenFunction
+### Uninstall specified runtime(s) of OpenFunction
 
 ```shell
-ofn uninstall --async
+ofn uninstall --runtime async
 ```
 
 or
 
 ```shell
-ofn uninstall --knative
+ofn uninstall --runtime knative,async
 ```
 
 ### For users who have limited access to gcr.io or github.com to uninstall OpenFunction

--- a/pkg/cmd/subcommand/demo.go
+++ b/pkg/cmd/subcommand/demo.go
@@ -131,7 +131,7 @@ func (i *Demo) RunKind(cl *k8s.Clientset, cmd *cobra.Command) error {
 		true,
 		true,
 		true,
-		false,
+		true,
 		i.OpenFunctionVersion,
 	)
 	if err != nil {

--- a/pkg/cmd/subcommand/install_test.go
+++ b/pkg/cmd/subcommand/install_test.go
@@ -1,0 +1,99 @@
+package subcommand
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type installConditions struct {
+	runtimes         []string
+	ingress          string
+	withoutCI        bool
+	withKeda         bool
+	withDapr         bool
+	withShipwright   bool
+	withIngressNginx bool
+	withKnative      bool
+	withAll          bool
+	version          string
+	wantFunc         func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool
+}
+
+func TestInstallCalculateConditions(t *testing.T) {
+	conditionSets := []*installConditions{
+		&installConditions{
+			runtimes:  []string{"knative", "async"},
+			ingress:   "nginx",
+			withoutCI: true,
+			withKeda:  false,
+			withDapr:  false,
+			withAll:   false,
+			version:   "latest",
+			wantFunc: func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool {
+				return !withShipwright && withKeda && withDapr && withKnative && withIngressNginx && !withCertManager && err == nil
+			},
+		},
+		&installConditions{
+			runtimes:  []string{"knative", "invalidRuntime"},
+			ingress:   "nginx",
+			withoutCI: false,
+			withKeda:  false,
+			withDapr:  false,
+			withAll:   false,
+			version:   "v0.4.0",
+			wantFunc: func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool {
+				return strings.Contains(err.Error(), "invalid runtime")
+			},
+		},
+		&installConditions{
+			runtimes:  []string{"knative"},
+			ingress:   "invalidIngress",
+			withoutCI: false,
+			withKeda:  false,
+			withDapr:  false,
+			withAll:   false,
+			version:   "v0.6.0",
+			wantFunc: func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool {
+				return strings.Contains(err.Error(), "invalid ingress")
+			},
+		},
+		&installConditions{
+			runtimes:    []string{"async"},
+			ingress:     "nginx",
+			withoutCI:   false,
+			withKeda:    false,
+			withDapr:    false,
+			withKnative: false,
+			withAll:     true,
+			version:     "v0.5.0",
+			wantFunc: func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool {
+				return withDapr && withKeda && withShipwright && withKnative && withIngressNginx && withCertManager && err == nil
+			},
+		},
+	}
+
+	for _, condition := range conditionSets {
+		ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+
+		install := NewInstall(ioStreams)
+		install.Runtimes = condition.runtimes
+		install.Ingress = condition.ingress
+		install.WithoutCI = condition.withoutCI
+		install.WithDapr = condition.withDapr
+		install.WithKnative = condition.withKnative
+		install.WithKeda = condition.withKeda
+		install.WithIngressNginx = condition.withIngressNginx
+		install.WithShipWright = condition.withShipwright
+		install.WithAll = condition.withAll
+		install.OpenFunctionVersion = condition.version
+
+		install.ValidateArgs()
+
+		err := install.calculateConditions()
+		if !condition.wantFunc(install.WithDapr, install.WithKeda, install.WithKnative, install.WithShipWright, install.WithIngressNginx, install.WithCertManager, err) {
+			t.Error("failed to calculate conditions.")
+		}
+	}
+}

--- a/pkg/cmd/subcommand/uninstall.go
+++ b/pkg/cmd/subcommand/uninstall.go
@@ -28,14 +28,14 @@ type Uninstall struct {
 	genericclioptions.IOStreams
 
 	Verbose             bool
+	Runtimes            []string
+	WithCI              bool
 	WithDapr            bool
 	WithKeda            bool
 	WithKnative         bool
 	WithShipWright      bool
 	WithCertManager     bool
-	WithIngress         bool
-	WithAsyncRuntime    bool
-	WithSyncRuntime     bool
+	WithIngressNginx    bool
 	WithAll             bool
 	RegionCN            bool
 	OpenFunctionVersion string
@@ -67,7 +67,7 @@ func NewCmdUninstall(restClient util.Getter, ioStreams genericclioptions.IOStrea
 ofn uninstall --all
 
 # Uninstall a specified runtime of OpenFunction
-ofn uninstall --async
+ofn uninstall --runtime async
 
 # For users who have limited access to gcr.io or github.com to uninstall OpenFunction
 ofn uninstall --region-cn --all
@@ -88,20 +88,18 @@ ofn uninstall --all --version v0.4.0
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			util.CheckErr(i.ValidateArgs(cmd, args))
+			util.CheckErr(i.ValidateArgs())
 			util.CheckErr(i.RunUninstall(cl, cmd))
 		},
 	}
 
+	cmd.PersistentFlags().StringSliceVarP(&i.Runtimes, "runtime", "r", []string{"knative"}, "List of runtimes to be uninstalled, optionally \"knative\", \"async\".")
 	cmd.Flags().BoolVar(&i.Verbose, "verbose", false, "Show verbose information.")
-	cmd.Flags().BoolVar(&i.WithDapr, "dapr", false, "For uninstalling Dapr.")
-	cmd.Flags().BoolVar(&i.WithKeda, "keda", false, "For uninstalling KEDA.")
-	cmd.Flags().BoolVar(&i.WithKnative, "knative", false, "For uninstalling Knative Serving (with Kourier as default gateway).")
-	cmd.Flags().BoolVar(&i.WithShipWright, "shipwright", false, "For uninstalling ShipWright.")
-	cmd.Flags().BoolVar(&i.WithCertManager, "cert-manager", false, "For uninstalling Cert Manager.")
-	cmd.Flags().BoolVar(&i.WithIngress, "ingress", false, "For uninstalling Ingress Nginx.")
-	cmd.Flags().BoolVar(&i.WithAsyncRuntime, "async", false, "For uninstalling OpenFunction Async Runtime (Dapr & Keda).")
-	cmd.Flags().BoolVar(&i.WithSyncRuntime, "sync", false, "For uninstalling OpenFunction Sync Runtime (To be supported).")
+	cmd.Flags().BoolVar(&i.WithCI, "with-ci", false, "For uninstalling the CI components.")
+	cmd.Flags().BoolVar(&i.WithDapr, "with-dapr", false, "For uninstalling Dapr.")
+	cmd.Flags().BoolVar(&i.WithKeda, "with-keda", false, "For uninstalling KEDA.")
+	cmd.Flags().BoolVar(&i.WithKnative, "with-knative", false, "For uninstalling Knative Serving (with Kourier as default gateway).")
+	cmd.Flags().BoolVar(&i.WithIngressNginx, "with-ingress-nginx", false, "For installing Ingress Nginx.")
 	cmd.Flags().BoolVar(&i.WithAll, "all", false, "For uninstalling all dependencies.")
 	cmd.Flags().BoolVar(&i.RegionCN, "region-cn", false, "For users who have limited access to gcr.io or github.com.")
 	cmd.Flags().BoolVar(&i.DryRun, "dry-run", false, "Used to prompt for the components and their versions to be uninstalled by the current command.")
@@ -112,15 +110,14 @@ ofn uninstall --all --version v0.4.0
 	// In order to avoid too many options causing misunderstandings among users,
 	// we have hidden the following parameters,
 	// but you can still find their usage instructions in the documentation.
-	cmd.Flags().MarkHidden("ingress")
-	cmd.Flags().MarkHidden("cert-manager")
-	cmd.Flags().MarkHidden("shipwright")
-	cmd.Flags().MarkHidden("keda")
-	cmd.Flags().MarkHidden("dapr")
+	cmd.Flags().MarkHidden("with-ingress-nginx")
+	cmd.Flags().MarkHidden("with-keda")
+	cmd.Flags().MarkHidden("with-dapr")
+	cmd.Flags().MarkHidden("with-knative")
 	return cmd
 }
 
-func (i *Uninstall) ValidateArgs(cmd *cobra.Command, args []string) error {
+func (i *Uninstall) ValidateArgs() error {
 	if i.OpenFunctionVersion == common.LatestVersion {
 		return nil
 	}
@@ -183,7 +180,9 @@ func (i *Uninstall) RunUninstall(cl *k8s.Clientset, cmd *cobra.Command) error {
 
 	// Determine which components need to be enabled
 	// and update all options to be consistent.
-	i.mergeConditions()
+	if err := i.calculateConditions(); err != nil {
+		return errors.Wrap(err, "failed to calculate conditions")
+	}
 	inventoryPending, err := inventory.GetInventory(
 		cl,
 		i.RegionCN,
@@ -192,7 +191,7 @@ func (i *Uninstall) RunUninstall(cl *k8s.Clientset, cmd *cobra.Command) error {
 		i.WithDapr,
 		i.WithShipWright,
 		i.WithCertManager,
-		i.WithIngress,
+		i.WithIngressNginx,
 		i.OpenFunctionVersion,
 	)
 	if err != nil {
@@ -296,7 +295,7 @@ func (i *Uninstall) RunUninstall(cl *k8s.Clientset, cmd *cobra.Command) error {
 		}
 	}
 
-	if i.WithIngress {
+	if i.WithIngressNginx {
 		if operator.Records.Ingress != "" {
 			count += 1
 			group.AddSpinner()
@@ -326,26 +325,36 @@ func (i *Uninstall) RunUninstall(cl *k8s.Clientset, cmd *cobra.Command) error {
 	return nil
 }
 
-func (i *Uninstall) mergeConditions() {
+func (i *Uninstall) calculateConditions() error {
+	i.WithCertManager = true
+	i.WithIngressNginx = true
+
+	// Calculate runtime condition
+	for _, rt := range i.Runtimes {
+		switch rt {
+		case "knative":
+			i.WithKnative = true
+		case "async":
+			i.WithDapr = true
+			i.WithKeda = true
+		default:
+			return errors.Errorf("invalid runtime: %s", rt)
+		}
+	}
+
 	// Update the corresponding conditions when WithAll is true
 	if i.WithAll {
 		i.WithDapr = true
 		i.WithKeda = true
-		i.WithIngress = true
 		i.WithKnative = true
 		i.WithShipWright = true
-		i.WithCertManager = true
 	}
 
-	// Update the corresponding conditions when WithAsyncRuntime is true
-	if i.WithAsyncRuntime {
-		i.WithDapr = true
-		i.WithKeda = true
+	if i.WithCI {
+		i.WithShipWright = true
 	}
 
-	// Update the corresponding conditions when WithSyncRuntime is true
-	//if i.WithSyncRuntime {
-	//}
+	return nil
 }
 
 func uninstallDapr(ctx context.Context, spinner *spinners.Spinner, cl *k8s.Clientset, operator *common.Operator, waitForCleared bool) {
@@ -465,28 +474,6 @@ func uninstallShipwright(ctx context.Context, spinner *spinners.Spinner, cl *k8s
 	spinner.Done()
 }
 
-func uninstallTektonPipelines(ctx context.Context, spinner *spinners.Spinner, cl *k8s.Clientset, operator *common.Operator, waitForCleared bool) {
-	ctx, done := context.WithCancel(ctx)
-	defer done()
-
-	spinner.Update("Uninstalling...")
-	yamls, err := operator.Inventory[inventory.TektonPipelinesName].GetYamlFile(operator.Records.TektonPipelines)
-	if err != nil {
-		spinner.Error(errors.Wrap(err, "Failed to get yaml file"))
-		return
-	}
-
-	if err := operator.Uninstall(ctx, cl, yamls["MAIN"], common.TektonPipelineNamespace, false, waitForCleared); err != nil {
-		spinner.Error(errors.Wrap(err, "Failed to uninstall Tekton Pipeline"))
-		return
-	}
-
-	// Reset version to null
-	operator.Records.TektonPipelines = ""
-
-	spinner.Done()
-}
-
 func uninstallCertManager(ctx context.Context, spinner *spinners.Spinner, cl *k8s.Clientset, operator *common.Operator, waitForCleared bool) {
 	ctx, done := context.WithCancel(ctx)
 	defer done()
@@ -505,6 +492,28 @@ func uninstallCertManager(ctx context.Context, spinner *spinners.Spinner, cl *k8
 
 	// Reset version to null
 	operator.Records.CertManager = ""
+
+	spinner.Done()
+}
+
+func uninstallTektonPipelines(ctx context.Context, spinner *spinners.Spinner, cl *k8s.Clientset, operator *common.Operator, waitForCleared bool) {
+	ctx, done := context.WithCancel(ctx)
+	defer done()
+
+	spinner.Update("Uninstalling...")
+	yamls, err := operator.Inventory[inventory.TektonPipelinesName].GetYamlFile(operator.Records.TektonPipelines)
+	if err != nil {
+		spinner.Error(errors.Wrap(err, "Failed to get yaml file"))
+		return
+	}
+
+	if err := operator.Uninstall(ctx, cl, yamls["MAIN"], common.TektonPipelineNamespace, false, waitForCleared); err != nil {
+		spinner.Error(errors.Wrap(err, "Failed to uninstall Tekton Pipeline"))
+		return
+	}
+
+	// Reset version to null
+	operator.Records.TektonPipelines = ""
 
 	spinner.Done()
 }

--- a/pkg/cmd/subcommand/uninstall_test.go
+++ b/pkg/cmd/subcommand/uninstall_test.go
@@ -1,0 +1,93 @@
+package subcommand
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type uninstallConditions struct {
+	runtimes         []string
+	withCI           bool
+	withKeda         bool
+	withDapr         bool
+	withShipwright   bool
+	withIngressNginx bool
+	withKnative      bool
+	withAll          bool
+	version          string
+	wantFunc         func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool
+}
+
+func TestUninstallCalculateConditions(t *testing.T) {
+	conditionSets := []*uninstallConditions{
+		&uninstallConditions{
+			runtimes: []string{"knative", "async"},
+			withCI:   false,
+			withKeda: false,
+			withDapr: false,
+			withAll:  false,
+			version:  "latest",
+			wantFunc: func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool {
+				return !withShipwright && withKeda && withDapr && withKnative && withIngressNginx && withCertManager && err == nil
+			},
+		},
+		&uninstallConditions{
+			runtimes: []string{"knative", "invalidRuntime"},
+			withCI:   false,
+			withKeda: false,
+			withDapr: false,
+			withAll:  false,
+			version:  "v0.4.0",
+			wantFunc: func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool {
+				return strings.Contains(err.Error(), "invalid runtime")
+			},
+		},
+		&uninstallConditions{
+			runtimes: []string{"knative"},
+			withKeda: true,
+			withCI:   true,
+			withDapr: false,
+			withAll:  false,
+			version:  "v0.6.0",
+			wantFunc: func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool {
+				return !withDapr && withKeda && withShipwright && withKnative && withIngressNginx && withCertManager && err == nil
+			},
+		},
+		&uninstallConditions{
+			runtimes:    []string{"async"},
+			withCI:      true,
+			withKeda:    false,
+			withDapr:    false,
+			withKnative: false,
+			withAll:     true,
+			version:     "v0.5.0",
+			wantFunc: func(withDapr bool, withKeda bool, withKnative bool, withShipwright bool, withIngressNginx bool, withCertManager bool, err error) bool {
+				return withDapr && withKeda && withShipwright && withKnative && withIngressNginx && withCertManager && err == nil
+			},
+		},
+	}
+
+	for _, condition := range conditionSets {
+		ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+
+		uninstall := NewUninstall(ioStreams)
+		uninstall.Runtimes = condition.runtimes
+		uninstall.WithCI = condition.withCI
+		uninstall.WithDapr = condition.withDapr
+		uninstall.WithKnative = condition.withKnative
+		uninstall.WithKeda = condition.withKeda
+		uninstall.WithIngressNginx = condition.withIngressNginx
+		uninstall.WithShipWright = condition.withShipwright
+		uninstall.WithAll = condition.withAll
+		uninstall.OpenFunctionVersion = condition.version
+
+		uninstall.ValidateArgs()
+
+		err := uninstall.calculateConditions()
+		if !condition.wantFunc(uninstall.WithDapr, uninstall.WithKeda, uninstall.WithKnative, uninstall.WithShipWright, uninstall.WithIngressNginx, uninstall.WithCertManager, err) {
+			t.Error("failed to calculate conditions.")
+		}
+	}
+}


### PR DESCRIPTION
for issue #32 

1. use `--runtime` to specify the runtimes that need to be installed.
2. display the flags by "users' perspective" and "technical's perspective", and by default do not display "technical's perspective" flags
3. add `install_test.go` and `uninstall_test.go`
4. add `make test`

Signed-off-by: laminar <fangtian@kubesphere.io>