### PR TITLE
feat: add `logs` subcommand

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -155,7 +155,7 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.7/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
-github.com/OpenFunction/OpenFunction v0.6.0 h1:BZZCgr4s6OFadPRhrO+vRKpo4BHznknZMMOHQc/I3hs=
+github.com/OpenFunction/OpenFunction v0.6.0 h1:VfIqhLBz3I9DBheWBjKuFHZ2L31NdDvf0ZcAkT+P+70=
 github.com/OpenFunction/OpenFunction v0.6.0/go.mod h1:7Ida4Kxst2Y+EnbIh/OELB22JXlJO81+PoXWJnB0sSw=
 github.com/ProtonMail/go-crypto v0.0.0-20210329181949-3900d675f39b/go.mod h1:HTM9X7e9oLwn7RiqLG0UVwVRJenLs3wN+tQ0NPAfwMQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -52,6 +52,7 @@ Find more information at:
 	cmd.AddCommand(subcommand.NewCmdCreate(kubeConfigFlags, ioStreams))
 	cmd.AddCommand(subcommand.NewCmdDelete(kubeConfigFlags, ioStreams))
 	cmd.AddCommand(subcommand.NewCmdGet(kubeConfigFlags, ioStreams))
+	cmd.AddCommand(subcommand.NewCmdLogs(kubeConfigFlags, ioStreams))
 	cmd.AddCommand(subcommand.NewCmdInstall(kubeConfigFlags, ioStreams))
 	cmd.AddCommand(subcommand.NewCmdUninstall(kubeConfigFlags, ioStreams))
 	cmd.AddCommand(subcommand.NewCmdDemo(kubeConfigFlags, ioStreams))

--- a/pkg/cmd/subcommand/logs.go
+++ b/pkg/cmd/subcommand/logs.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2022 The OpenFunction Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subcommand
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/OpenFunction/cli/pkg/cmd/util"
+	cc "github.com/OpenFunction/cli/pkg/cmd/util/client"
+	client "github.com/openfunction/pkg/client/clientset/versioned"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8s "k8s.io/client-go/kubernetes"
+)
+
+// Logs is the commandline for `logs` sub command
+type Logs struct {
+	*genericclioptions.IOStreams
+
+	functionName  string
+	containerName string
+	namespace     string
+
+	Follow bool
+
+	functionClient client.Interface
+	clientSet      *k8s.Clientset
+}
+
+// NewCmdLogs builds the `logs` sub command
+func NewCmdLogs(cf *genericclioptions.ConfigFlags, ioStreams genericclioptions.IOStreams) *cobra.Command {
+
+	l := &Logs{
+		IOStreams:     &ioStreams,
+		containerName: "function",
+	}
+
+	cmd := &cobra.Command{
+		Use:                   `logs [OPTIONS] FUNCTION_NAME [CONTAINER_NAME]`,
+		DisableFlagsInUseLine: true,
+		Short:                 "Get the logs from the serving pods created by the function",
+		Long:                  `Get the logs from the serving pods created by the function`,
+		Example: `
+  # Get tht logs from the 'function' container in the serving pods created by the function whose name is 'demo-function'
+  ofn logs demo-function
+
+  # Get tht logs from the 'extra' container (a container whose name is not 'function') in the serving pods created by the function whose name is 'demo-function'
+  ofn logs demo-function extra
+
+  # Begin streaming the logs from the 'function' container in the serving pods created by the function whose name is 'demo-function'
+  ofn logs -f demo-function
+`,
+		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			return l.preRun(cf, args)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(l.run())
+		},
+	}
+	cmd.Flags().BoolVarP(&l.Follow, "follow", "f", l.Follow, "Specify if the logs should be streamed")
+	return cmd
+}
+
+func (l *Logs) preRun(cf *genericclioptions.ConfigFlags, args []string) error {
+	config, clientSet, err := cc.NewKubeConfigClient(cf)
+	if err != nil {
+		panic(err)
+	}
+	l.clientSet = clientSet
+	err = cc.SetConfigDefaults(config)
+	if err != nil {
+		return err
+	}
+	l.functionClient = client.NewForConfigOrDie(config)
+
+	if cf.Namespace != nil && *(cf.Namespace) != "" {
+		l.namespace = *(cf.Namespace)
+	} else {
+		if l.namespace, _, err = cf.ToRawKubeConfigLoader().Namespace(); err != nil {
+			return err
+		}
+	}
+
+	if len(args) < 1 {
+		return errors.New("missing argument: FUNCTION_NAME")
+	}
+	l.functionName = args[0]
+	if len(args) > 1 {
+		l.containerName = args[1]
+	}
+	return nil
+}
+
+func (l *Logs) run() error {
+	ctx := context.Background()
+	f, err := l.functionClient.CoreV1beta1().Functions(l.namespace).Get(ctx, l.functionName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if f.Status.Serving == nil {
+		return nil
+	}
+	serving := f.Status.Serving.ResourceRef
+	listOpt := metav1.ListOptions{LabelSelector: fmt.Sprintf("openfunction.io/serving=%s", serving)}
+	podInterface := l.clientSet.CoreV1().Pods(l.namespace)
+	podList, err := podInterface.List(ctx, listOpt)
+	if err != nil {
+		return err
+	}
+	readerList := make([]io.Reader, 0, len(podList.Items))
+	for _, pod := range podList.Items {
+		logReader, err := podInterface.GetLogs(pod.Name, &corev1.PodLogOptions{Follow: l.Follow, Container: l.containerName}).Stream(ctx)
+		defer logReader.Close()
+		if err != nil {
+			return err
+		}
+		readerList = append(readerList, logReader)
+	}
+	reader := io.MultiReader(readerList...)
+	_, err = io.Copy(l.IOStreams.Out, reader)
+	return err
+}


### PR DESCRIPTION
This PR adds the `logs` subcommand.

The usage of this subcommand is:

```
$ ofn logs -h
Get the logs from the serving pods created by the function

Usage:
  ofn logs [OPTIONS] FUNCTION_NAME [CONTAINER_NAME]

Examples:

  # Get tht logs from the 'function' container in the serving pods created by the function whose name is 'demo-function'
  ofn logs demo-function

  # Get tht logs from the 'extra' container (a container whose name is not 'function') in the serving pods created by the function whose name is 'demo-function'
  ofn logs demo-function extra

  # Begin streaming the logs from the 'function' container in the serving pods created by the function whose name is 'demo-function'
  ofn logs -f demo-function


Flags:
  -f, --follow   Specify if the logs should be streamed
  -h, --help     help for logs

Global Flags:
      --as string                      Username to impersonate for the operation
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir string               Default cache directory (default "/Users/loheagn/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string               If present, the namespace scope for this CLI request
      --password string                Password for basic authentication to the API server
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
      --username string                Username for basic authentication to the API server

```

Fix #36 

Signed-off-by: loheagn <loheagn@icloud.com>